### PR TITLE
Add DeepSeek model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Follow these steps to get the application running locally for development and te
        # OPENAI_API_BASE=<custom_api_base>
        ```
 
+       The model dropdown in the UI includes Gemini models as well as
+       a **DeepSeek (OpenAI)** option. Select this option to use the
+       `deepseek-chat` model via an OpenAI-compatible API.
+
 **2. Install Dependencies:**
 
 **Backend:**

--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -160,6 +160,14 @@ export const InputForm: React.FC<InputFormProps> = ({
                     <Cpu className="h-4 w-4 mr-2 text-purple-400" /> 2.5 Pro
                   </div>
                 </SelectItem>
+                <SelectItem
+                  value="deepseek-chat"
+                  className="hover:bg-neutral-600 focus:bg-neutral-600 cursor-pointer"
+                >
+                  <div className="flex items-center">
+                    <Cpu className="h-4 w-4 mr-2 text-green-400" /> DeepSeek (OpenAI)
+                  </div>
+                </SelectItem>
               </SelectContent>
             </Select>
           </div>


### PR DESCRIPTION
## Summary
- add a DeepSeek (OpenAI) option to the model dropdown
- document the new option in README

## Testing
- `make -C backend lint` *(fails: found 37 errors)*
- `npm run lint` in `frontend` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68414f567af08332941c04d894258475