### PR TITLE
Add OpenAI environment placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Follow these steps to get the application running locally for development and te
 -   Node.js and npm (or yarn/pnpm)
 -   Python 3.8+
 -   **`GEMINI_API_KEY`**: The backend agent requires a Google Gemini API key.
+-   **`OPENAI_API_KEY`** _(optional)_: API key used when `LLM_PROVIDER` is set to `openai`.
+-   **`OPENAI_API_BASE`** _(optional)_: Custom base URL for an OpenAI-compatible API.
     1.  Navigate to the `backend/` directory.
     2.  Create a file named `.env` by copying the `backend/.env.example` file.
     3.  Open the `.env` file and add your Gemini API key: `GEMINI_API_KEY="YOUR_ACTUAL_API_KEY"`.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,3 @@
 # GEMINI_API_KEY=
-# OPENAI_API_KEY=
-# OPENAI_API_BASE=
+# OPENAI_API_KEY=<your_openai_api_key>
+# OPENAI_API_BASE=<optional_custom_base_url>


### PR DESCRIPTION
## Summary
- add example placeholders for OpenAI API variables in `.env.example`
- document `OPENAI_API_KEY` and `OPENAI_API_BASE` in the setup instructions

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68415636ce2883329f2783d8a96cb441